### PR TITLE
Fix deployment triggers with path filters

### DIFF
--- a/.github/workflows/content-pages.yml
+++ b/.github/workflows/content-pages.yml
@@ -4,6 +4,12 @@ on:
   # Auto-deploy on pushes to main
   push:
     branches: [main]
+    paths:
+      - 'content/**'
+      - 'static/**'
+      - 'data/**'
+      - 'i18n/**'
+      - 'hugo.toml'
   # Manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
Resolves #6 by adding path filters to `content-pages.yml` workflow to prevent unnecessary deployments on code changes.

## Changes
- Added path filters to `content-pages.yml` workflow trigger
- Only triggers auto-deployment when content/static files change:
  - `content/**` - All content files
  - `static/**` - Static assets
  - `data/**` - Data files
  - `i18n/**` - Internationalization files
  - `hugo.toml` - Hugo configuration

## Behavior

**Auto-deploys** on push to main when:
- Creating/editing notes, blog posts, publications, projects
- Adding/updating static assets (images, CSS, JS)
- Modifying Hugo config

**Does NOT auto-deploy** when:
- Changing theme files, layouts, workflows, scripts
- Other platform/code changes (use release workflow instead)

**Still available**:
- Manual deployment via workflow_dispatch
- Release-based deployment via hugo.yml for platform changes