### PR TITLE
feat: configure custom domain rudolfjs.id.au for GitHub Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+rudolfjs.id.au

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://rudolfj.github.io/'
+baseURL = 'https://rudolfjs.id.au/'
 languageCode = 'en-us'
 title = 'Rudolf J'
 theme = 'minimal-research'


### PR DESCRIPTION
## Summary

Configure the custom domain `rudolfjs.id.au` for GitHub Pages deployment.

## Changes

- **`CNAME`** — new file pointing to `rudolfjs.id.au`, required by GitHub Pages for custom domain serving
- **`hugo.toml`** — update `baseURL` from `https://rudolfj.github.io/` to `https://rudolfjs.id.au/`

## Notes

- No workflow changes needed — both `hugo.yml` and `content-pages.yml` use `actions/configure-pages@v5` which dynamically resolves the base URL from the repo's Pages settings
- DNS A records for `rudolfjs.id.au` have been configured in Cloudflare (DNS Only, not proxied)
- After merge, enable the custom domain in **Settings > Pages** and check **Enforce HTTPS**