### PR TITLE
feat: add presentations section with BIOE6901 guest lecture

### DIFF
--- a/content/presentations/_index.md
+++ b/content/presentations/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Presentations"
+description: "Talks and presentations on digital health, machine learning, and clinical informatics"
+---

--- a/content/presentations/bioe6901-samd-healthcare.md
+++ b/content/presentations/bioe6901-samd-healthcare.md
@@ -1,0 +1,14 @@
+---
+title: "Software-as-a-Device (SaMD) in Healthcare"
+subtitle: "Research to Implementation - Sepsis Predictor Case Study"
+date: 2026-04-13
+event_date: 2026-04-16
+event: "BIOE6901 - Week 7 Tutorial"
+venue: "University of Queensland"
+year: 2026
+presentation_url: "/presentations/bioe6901/index.html"
+tags: ["SaMD", "sepsis", "TGA", "ethics", "digital health"]
+draft: false
+---
+
+A guest lecture covering the journey from research idea to clinical implementation of AI in healthcare, using a sepsis predictor as a case study. Topics include human research ethics, data governance, privacy frameworks, and TGA regulation of Software-as-a-Medical-Device (SaMD).

--- a/layouts/presentations/list.html
+++ b/layouts/presentations/list.html
@@ -1,0 +1,51 @@
+{{ define "main" }}
+  <div class="max-w-6xl mx-auto">
+    <div class="mb-12">
+      <h1 class="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">{{ .Title }}</h1>
+      <p class="text-lg text-gray-600 dark:text-gray-400">{{ .Description }}</p>
+    </div>
+
+    {{ $sortedPages := .Pages.ByDate.Reverse }}
+
+    {{ range $sortedPages }}
+      <div class="mb-8 p-6 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 transition-colors">
+        <a href="{{ .RelPermalink }}" class="block">
+          <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">{{ .Title }}</h2>
+          {{ with .Params.subtitle }}
+            <p class="text-lg text-gray-600 dark:text-gray-400 mb-3">{{ . }}</p>
+          {{ end }}
+          <div class="flex flex-wrap items-center gap-4 text-sm text-gray-500 dark:text-gray-400 mb-3">
+            {{ with .Params.event }}
+              <span class="flex items-center">
+                <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+                </svg>
+                {{ . }}
+              </span>
+            {{ end }}
+            <time class="flex items-center">
+              <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+              {{ with .Params.event_date }}{{ time.Format "2 January 2006" . }}{{ else }}{{ .Date.Format "2 January 2006" }}{{ end }}
+            </time>
+          </div>
+          <p class="text-gray-600 dark:text-gray-400">{{ .Summary }}</p>
+        </a>
+        {{ with .Params.tags }}
+          <div class="mt-3 flex flex-wrap gap-2">
+            {{ range . }}
+              <span class="tag">#{{ . }}</span>
+            {{ end }}
+          </div>
+        {{ end }}
+      </div>
+    {{ end }}
+
+    {{ if not $sortedPages }}
+      <div class="text-center py-12">
+        <p class="text-gray-500 dark:text-gray-400">No presentations available yet.</p>
+      </div>
+    {{ end }}
+  </div>
+{{ end }}

--- a/layouts/presentations/single.html
+++ b/layouts/presentations/single.html
@@ -1,0 +1,64 @@
+{{ define "main" }}
+<article class="max-w-6xl mx-auto">
+    <header class="mb-8">
+        <h1 class="text-4xl font-bold mb-3 text-gray-900 dark:text-gray-100">{{ .Title }}</h1>
+        {{ with .Params.subtitle }}
+          <p class="text-xl text-gray-600 dark:text-gray-400 mb-4">{{ . }}</p>
+        {{ end }}
+        <div class="flex flex-wrap items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+            {{ with .Params.event }}
+              <span class="flex items-center">
+                <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+                </svg>
+                {{ . }}
+              </span>
+            {{ end }}
+            {{ with .Params.venue }}
+              <span class="flex items-center">
+                <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                {{ . }}
+              </span>
+            {{ end }}
+            <time class="flex items-center">
+              <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+              {{ with .Params.event_date }}{{ time.Format "2 January 2006" . }}{{ else }}{{ .Date.Format "2 January 2006" }}{{ end }}
+            </time>
+        </div>
+        {{ with .Params.tags }}
+          <div class="mt-4 flex flex-wrap gap-2">
+            {{ range . }}
+              <span class="tag">#{{ . }}</span>
+            {{ end }}
+          </div>
+        {{ end }}
+    </header>
+
+    {{ with .Content }}
+      <div class="prose dark:prose-invert max-w-none mb-8">
+        {{ . }}
+      </div>
+    {{ end }}
+
+    {{ with .Params.presentation_url }}
+      <div class="mb-8">
+        <a href="{{ . }}" target="_blank" rel="noopener"
+           class="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+          View Presentation
+        </a>
+      </div>
+
+      <div class="rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
+        <iframe src="{{ . }}" class="w-full" style="aspect-ratio: 16/9;" loading="lazy" sandbox="allow-scripts allow-same-origin"></iframe>
+      </div>
+    {{ end }}
+</article>
+{{ end }}


### PR DESCRIPTION
## Summary

Adds an unlisted presentations section to host self-contained Quarto RevealJS presentations. Pages are accessible via direct URL but not linked in site navigation.

## Changes

- **`content/presentations/_index.md`** — section list page
- **`content/presentations/bioe6901-samd-healthcare.md`** — metadata page for the BIOE6901 guest lecture (SaMD in Healthcare)
- **`layouts/presentations/list.html`** — list template with event, venue, date, and tags
- **`layouts/presentations/single.html`** — single page with iframe preview + "View Presentation" fullscreen button
- **`static/presentations/bioe6901/index.html`** — self-contained Quarto RevealJS HTML (`embed-resources: true`)

## Design decisions

- **Unlisted**: no nav menu entry — only accessible via direct link
- **Static + Content split**: raw HTML in `static/` (served as-is), Hugo content pages provide metadata and templating
- **`event_date` front matter**: separate from Hugo's `date` field to avoid future-date filtering while displaying the real presentation date (16 April 2026)

## Accessible at

- `/presentations/bioe6901-samd-healthcare/` — metadata page with embedded preview
- `/presentations/bioe6901/index.html` — full RevealJS presentation