### PR TITLE
ci: auto-clean stale GitHub Pages deployments

### DIFF
--- a/.changes/unreleased/Added-20260414-083355.yaml
+++ b/.changes/unreleased/Added-20260414-083355.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Auto-clean stale GitHub Pages deployments after each deploy
+time: 2026-04-14T08:33:55.532165333+10:00

--- a/.changes/unreleased/Added-20260414-083359.yaml
+++ b/.changes/unreleased/Added-20260414-083359.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Presentations section for hosting self-contained Quarto RevealJS presentations (unlisted, direct-link access only)
+time: 2026-04-14T08:33:59.432192+10:00

--- a/.github/workflows/content-pages.yml
+++ b/.github/workflows/content-pages.yml
@@ -17,6 +17,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  deployments: write
 
 concurrency:
   group: "pages"
@@ -74,3 +75,28 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+      - name: Clean up old deployments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployments = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: 'github-pages',
+              per_page: 100
+            });
+            const stale = deployments.data.slice(1);
+            for (const d of stale) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: d.id,
+                state: 'inactive'
+              });
+              await github.rest.repos.deleteDeployment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: d.id
+              });
+            }
+            console.log(`Cleaned up ${stale.length} old deployments`);

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  deployments: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -99,3 +100,28 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+      - name: Clean up old deployments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployments = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: 'github-pages',
+              per_page: 100
+            });
+            const stale = deployments.data.slice(1);
+            for (const d of stale) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: d.id,
+                state: 'inactive'
+              });
+              await github.rest.repos.deleteDeployment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: d.id
+              });
+            }
+            console.log(`Cleaned up ${stale.length} old deployments`);


### PR DESCRIPTION
## Problem

GitHub Pages deployments accumulate indefinitely — we had 33 stale deployment records. These are inactive metadata records that GitHub never cleans up automatically.

## Solution

Add a "Clean up old deployments" step to both deploy workflows (`hugo.yml` and `content-pages.yml`) that runs after each successful deployment:

1. Lists all `github-pages` deployments
2. Marks all except the latest as `inactive`
3. Deletes them

Uses `actions/github-script@v7` with the built-in Octokit client — no third-party action dependency.

## Changes

- `.github/workflows/content-pages.yml` — add `deployments: write` permission + cleanup step
- `.github/workflows/hugo.yml` — add `deployments: write` permission + cleanup step
- Changie entries for both the presentations feature (PR #23) and this CI cleanup

## Manual cleanup already done

The 32 stale deployments were already deleted manually via the API in this session. This PR ensures they don't accumulate again.